### PR TITLE
Improve FindFileModule logic

### DIFF
--- a/module.go
+++ b/module.go
@@ -9,6 +9,7 @@ import (
 	"github.com/robertkrimen/otto"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 )
 
 // ModuleLoader is declared to load a module.
@@ -146,7 +147,10 @@ func FindFileModule(name, pwd string, paths []string) (string, error) {
 				entryPoint = "./index.js"
 			}
 
-			return filepath.Abs(filepath.Join(v, entryPoint))
+			if !strings.HasPrefix(entryPoint, ".") {
+				entryPoint = "./" + entryPoint
+			}
+			return FindFileModule(entryPoint, v, paths)
 		}
 
 		ok, err = isFile(v)

--- a/module.go
+++ b/module.go
@@ -95,24 +95,29 @@ func FindFileModule(name, pwd string, paths []string) (string, error) {
 		return "", errors.New("Empty module name")
 	}
 
+	add := func(choices []string, name string) []string {
+		ext := filepath.Ext(name)
+		if ext != ".js" && ext != ".json" {
+			choices = append(choices, name+".js", name+".json")
+		}
+		choices = append(choices, name)
+		return choices
+	}
+
 	var choices []string
 	if name[0] == '.' || filepath.IsAbs(name) {
 		if name[0] == '.' {
 			name = filepath.Join(pwd, name)
 		}
 
-		ext := filepath.Ext(name)
-		if ext != ".js" && ext != ".json" {
-			choices = append(choices, name+".js", name+".json")
-		}
-		choices = append(choices, name)
+		choices = add(choices, name)
 	} else {
 		if pwd != "" {
-			choices = append(choices, filepath.Join(pwd, "node_modules", name))
+			choices = add(choices, filepath.Join(pwd, "node_modules", name))
 		}
 
 		for _, v := range paths {
-			choices = append(choices, filepath.Join(v), name)
+			choices = add(choices, filepath.Join(v, name))
 		}
 	}
 

--- a/module.go
+++ b/module.go
@@ -140,7 +140,9 @@ func FindFileModule(name, pwd string, paths []string) (string, error) {
 				if err != nil {
 					return "", err
 				}
-			} else {
+			}
+
+			if entryPoint == "" {
 				entryPoint = "./index.js"
 			}
 

--- a/module.go
+++ b/module.go
@@ -101,11 +101,11 @@ func FindFileModule(name, pwd string, paths []string) (string, error) {
 			name = filepath.Join(pwd, name)
 		}
 
-		choices = append(choices, name)
 		ext := filepath.Ext(name)
 		if ext != ".js" && ext != ".json" {
 			choices = append(choices, name+".js", name+".json")
 		}
+		choices = append(choices, name)
 	} else {
 		if pwd != "" {
 			choices = append(choices, filepath.Join(pwd, "node_modules", name))


### PR DESCRIPTION
`require`ing some `npm` modules doesn't work because `motto` has a different logic for finding the file to load than Node. Fix some of these differences.